### PR TITLE
need to also setHeight on init

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -517,7 +517,7 @@ $.fn.floatThead = function(map){
         var calculateFloatContainerPos = calculateFloatContainerPosFn();
         var repositionFloatContainer = repositionFloatContainerFn();
         
-        repositionFloatContainer(calculateFloatContainerPos('init'), true); //this must come after reflow because reflow changes scrollLeft back to 0 when it rips out the thead
+        repositionFloatContainer(calculateFloatContainerPos('init'), true, true); //this must come after reflow because reflow changes scrollLeft back to 0 when it rips out the thead
         
         var windowScrollDoneEvent = _.debounce(function(){
             repositionFloatContainer(calculateFloatContainerPos('windowScrollDone'), false);


### PR DESCRIPTION
I found that this fixed a bug with incorrect header height.

If the thead has a different height to the table rows (e.g. col heading text wrapped on two lines) then the call to repositionFloatContainerFn() at "init" was not setting height and so the new header had the wrong height.
