### PR TITLE
Possible solution for fluid layout issue

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -40,6 +40,8 @@
       },
       floatTableClass: 'floatThead-table',
 	    floatContainerClass: 'floatThead-container',
+      tableFixedHeight: true, //if set to False it will use absolute positioning with top, bottom, left and right set to 0, instead of
+        // fixed height
       debug: false //print possible issues (that don't prevent script loading) to console, if console exists.
     }
   };
@@ -169,6 +171,7 @@
       if(useAbsolutePositioning == null){ //defaults: locked=true, !locked=false
         useAbsolutePositioning = opts.scrollContainer($table).length;
       }
+      var tableFixedHeight = opts.tableFixedHeight;
       var $caption = $table.find("caption");
       var haveCaption = $caption.length == 1;
       if(haveCaption){
@@ -211,7 +214,12 @@
           if(!relativeToScrollContainer || alwaysWrap){
             var css = {"paddingLeft": $container.css('paddingLeft'), "paddingRight": $container.css('paddingRight')};
             $floatContainer.css(css);
-            $container = $container.wrap("<div style='position: relative; clear:both;'></div>").parent();
+            if(tableFixedHeight){
+              $container = $container.wrap("<div style='position: relative; clear:both;'></div>").parent();
+            }
+            else{
+              $container = $container.wrap("<div style='position: absolute; top:0; bottom: 0; left: 0; right: 0; clear:both;'></div>").parent();
+            }
             wrappedContainer = true;
           }
           return $container;


### PR DESCRIPTION
If table wrapper doesn't have a fixed height (as in examples) but it uses absolute positioning to use as much space as allowed by surrounding elements current implementation didn't work because the div container

    $container = $container.wrap("<div style='position: relative; clear:both;'></div>").parent();

will have a computed height of zero, and so will happen with the table wraper put inside.

Changing the container to use absolute positioning and setting top, bottom, right and left to zero (ie, use all available space) will solve the problem and allow us to use tables which height is not fixed.

Anyway, I've set that configurable, behing default behaviour as it was.