### PR TITLE
Fix header not disappearing after table out of view

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -493,6 +493,7 @@
           }
           var top, left, tableHeight;
 
+          tableHeight = $table.outerHeight();
           if(locked && useAbsolutePositioning){ //inner scrolling, absolute positioning
             if (tableContainerGap >= scrollingContainerTop) {
               var gap = tableContainerGap - scrollingContainerTop;
@@ -504,7 +505,6 @@
             }
             left = 0;
           } else if(!locked && useAbsolutePositioning) { //window scrolling, absolute positioning
-            tableHeight = $table.outerHeight();
             if(windowTop > floatEnd + tableHeight + captionScrollOffset){
               top = tableHeight - floatContainerHeight + captionScrollOffset; //scrolled past table
             } else if (tableOffset.top > windowTop + scrollingTop) {
@@ -516,7 +516,7 @@
             }
             left =  0;
           } else if(locked && !useAbsolutePositioning){ //inner scrolling, fixed positioning
-            if (tableContainerGap > scrollingContainerTop) {
+            if (tableContainerGap > scrollingContainerTop || scrollingContainerTop - tableContainerGap > tableHeight) {
               top = tableOffset.top - windowTop;
               unfloat();
             } else {


### PR DESCRIPTION
When using with useAbsolutePositioning: false and given scrollContainer like this:

```
$('.floathead]').floatThead(
  scrollContainer: ($tbl) -> $tbl.closest($tbl.data('scroll'))
  useAbsolutePositioning: false
)
```
