### PR TITLE
add iframe option

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -37,7 +37,8 @@
     floatWrapperClass: 'floatThead-wrapper',
     floatContainerClass: 'floatThead-container',
     copyTableClass: true, //copy 'class' attribute from table into the floated table so that the styles match.
-    debug: false //print possible issues (that don't prevent script loading) to console, if console exists.
+    debug: false, //print possible issues (that don't prevent script loading) to console, if console exists.
+    iframe: false
   };
 
   var util = window._;
@@ -56,7 +57,7 @@
     return width == 0;
   };
 
-  var $window = $(window);
+  var $window;
   var floatTheadCreated = 0;
 
 
@@ -161,6 +162,8 @@
         debug("jQuery.floatThead: used ["+key+"] key to init plugin, but that param is not an option for the plugin. Valid options are: "+ (util.keys($.floatThead.defaults)).join(', '));
       }
     });
+
+    $window = opts.iframe ? $(window.parent) : $(window);
 
     this.filter(':not(.'+opts.floatTableClass+')').each(function(){
       var floatTheadId = floatTheadCreated;


### PR DESCRIPTION
Was just using this to try to fix a header on a table inside of an iframe with no overflow — but the iframe didn't recognize when I scrolled. Added this `iframe` option, which sets `$window` to `$(window.parent)` so that scroll events are detected.

The way to use this feature like a pro is to set the `scrollingTop` function so that the header gets fixed at the top of the window:

```
var $table = $('#table-id');
$table.floatThead({
  scrollingTop: function($table) {
    try {
      return -$(window.parent.document).find('#table-id').offset().top;
    }
    catch(e) {
      return 0;
    }
  }
});
```

The reason for the try/catch is so you can build and test the table without having to put it inside an iframe — in other words, `window.parent.document` doesn't have to exist, but if it does, it will be used as a reference point.
