### PR TITLE
Change iframe scrolling to use scrollContainer

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -195,7 +195,10 @@
 
       var $fthGrp = $('<fthfoot style="display:table-footer-group;"/>');
 
-      var locked = $scrollContainer.length > 0;
+      if($scrollContainer.length > 0){
+        var iframe = $.isWindow($scrollContainer[0]);
+        var locked = !iframe;
+      }
       var wrappedContainer = false; //used with absolute positioning enabled. did we need to wrap the scrollContainer/table with a relative div?
       var $wrapper = $([]); //used when absolute positioning enabled - wraps the table and the float container
       var absoluteToFixedOnScroll = ieVersion <= 9 && !locked && useAbsolutePositioning; //on ie using absolute positioning doesnt look good with window scrolling, so we change positon to fixed on scroll, and then change it back to absolute when done.
@@ -490,6 +493,10 @@
             scrollingContainerTop = $scrollContainer.scrollTop();
             scrollContainerLeft =  $scrollContainer.scrollLeft();
           }
+          if(iframe) {
+            windowTop = scrollingContainerTop;
+            windowLeft = scrollContainerLeft;
+          }
           if(isChrome && (windowTop < 0 || windowLeft < 0)){ //chrome overscroll effect at the top of the page - breaks fixed positioned floated headers
             return;
           }
@@ -646,7 +653,7 @@
         calculateFloatContainerPos = calculateFloatContainerPosFn();
         repositionFloatContainer(calculateFloatContainerPos('reflow'), true);
       }, 1);
-      if(locked){ //internal scrolling
+      if(locked || iframe){ //internal scrolling
         if(useAbsolutePositioning){
           $scrollContainer.on(eventName('scroll'), containerScrollEvent);
         } else {


### PR DESCRIPTION
Alright - cool. Lemme know what you think about this approach. Here's the usage:

```
$table = $('#framediv').find('table');
$table.floatThead({
    scrollingTop: function($table) {
      try {
        return -$(window.parent.document).find('#framediv').offset().top;
      }
      catch(e) {
        return 0;
      }
    },
    scrollContainer: function($table) {
      return $(window.parent);
    }
  });
```

It works when you set scrollContainer to return $(window.parent) basically by listening to scroll events coming from the scroll container (the parent) and then behaving as if that parent were the window (as opposed to an actual scroll container). Does that make sense?

I can't think of a good way to bake the scrollingTop function in. Problem is that you don't want to do something like `return -$(window.parent.document).find('iframe').offset().top;` or `return -$(window.parent.document).find('table').offset().top;` cause you might have other iframes or tables on the page.

I tested destroy...worked like a charm!
