### PR TITLE
Remove css min-width from table on destroy

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -684,6 +684,7 @@
           if (wrappedContainer) {
             $scrollContainer.unwrap();
           }
+          $table.css('minWidth', '');
           $floatContainer.remove();
           $table.data('floatThead-attached', false);
 


### PR DESCRIPTION
The min-width property is added when the table exceeds its bounds.
