### PR TITLE
floatThead-container width when scrollContainer overflow is hidden

### DIFF
--- a/dist/jquery.floatThead.js
+++ b/dist/jquery.floatThead.js
@@ -296,9 +296,10 @@
       function setFloatWidth(){
         var tableWidth = $table.outerWidth();
         var width = $scrollContainer.width() || tableWidth;
-        $floatContainer.width(width - scrollbarOffset.vertical);
+        var noOffsetWidth = ($scrollContainer.css("overflow-y") != 'hidden')?width - scrollbarOffset.vertical:width;    
+        $floatContainer.width(noOffsetWidth);
         if(locked){
-          var percent = 100 * tableWidth / (width - scrollbarOffset.vertical);
+          var percent = 100 * tableWidth / (noOffsetWidth);
           $floatTable.css('width', percent+'%');
         } else {
           $floatTable.outerWidth(tableWidth);


### PR DESCRIPTION
I have two tables with synchronous scroll. One of them has hidden overflow-y. 
Try to scroll right one (table2) vertically, and you'll see bug in table1's header.

http://jsfiddle.net/8cxe4qxc/
Screenshot: http://take.ms/Z5SBq
