### PR TITLE
refresh table cell reference on reflow

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -432,12 +432,15 @@
       function reflow(){
         var i;
         var numCols = columnNum(); //if the tables columns change dynamically since last time (datatables) we need to rebuild the sizer rows and get new count
+
         return function(){
-          var $rowCells = getSizingRow($table, $tableCells, $fthCells, ieVersion);
+          var $tCells = $tableColGroup.find('col');
+          var $rowCells = getSizingRow($table, $tCells, $fthCells, ieVersion);
+
           if($rowCells.length == numCols && numCols > 0){
             if(!existingColGroup){
               for(i=0; i < numCols; i++){
-                $tableCells.eq(i).css('width', '');
+                $tCells.eq(i).css('width', '');
               }
             }
             unfloat();
@@ -447,7 +450,7 @@
             }
             for(i=0; i < numCols; i++){
               $headerCells.eq(i).width(widths[i]);
-              $tableCells.eq(i).width(widths[i]);
+              $tCells.eq(i).width(widths[i]);
             }
             refloat();
           } else {


### PR DESCRIPTION
Found a bug while using this with Angular. Angular destroyed the table header and re-rendered it; however floatthead kept a reference to the old table header and didn't realize that those elements no longer existed in the DOM. Because the number of columns didn't change, the call to `columnNum()` the table cell reference was never refreshed and floatthead failed to render the table properly.

This fix forces floatthead to fetch a new reference each time reflow is called. 
