### PR TITLE
ajax width issue 'fix'

### DIFF
--- a/dist/jquery.floatThead.js
+++ b/dist/jquery.floatThead.js
@@ -776,6 +776,16 @@
           }
         }
       });
+
+      $(document).ajaxComplete(function () {
+          var isHtml = new RegExp(/content-type:\s?text\/html/i).test(arguments[1].getAllResponseHeaders());
+          if (isHtml) {
+              calculateScrollBarSize();
+              ensureReflow();
+              repositionFloatContainer(calculateFloatContainerPos('resize'), true, true);
+              repositionFloatContainer(calculateFloatContainerPos('windowScrollDone'), false);
+          }
+      });
     });
     return this;
   };
@@ -843,4 +853,3 @@
     return that;
   })();
 })(jQuery);
-


### PR DESCRIPTION
I had an issue using this plugin. When data is loaded with AJAX into a table that previously fitted on the screen but now requires scrollbars, the table width seems fail to recalculate and continues as if the scrollbars were not there. At least this is what I think is going on. I've included my work around and a screenshot of the problem I was having:

![capture](https://cloud.githubusercontent.com/assets/5046018/5706924/a5da4e20-9a7c-11e4-9ea6-b298714b3e0f.PNG)

With this workaround I made everything started working perfectly, but I suspect it might not be ideal. I tested in Chrome and IE back to IE9.

Thanks

Garry