### PR TITLE
IE offsetWidthfloat calculation

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -53,6 +53,32 @@
   var isFF = /Gecko\//.test(navigator.userAgent);
   var isWebkit = /WebKit\//.test(navigator.userAgent);
 
+  // in IE, offsetWidth returns an integer, but table cell width returns a float, this causes cell text to be split over two lines
+  // code from http://vadikom.com/dailies/offsetwidth-offsetheight-useless-in-ie9-firefox4/
+  function _getOffset(elm, height) {
+    var cStyle = elm.ownerDocument && elm.ownerDocument.defaultView && elm.ownerDocument.defaultView.getComputedStyle
+      && elm.ownerDocument.defaultView.getComputedStyle(elm, null),
+      ret = cStyle && cStyle.getPropertyValue(height ? 'height' : 'width') || '';
+    if (ret && ret.indexOf('.') > -1) {
+      ret = parseFloat(ret)
+        + parseInt(cStyle.getPropertyValue(height ? 'padding-top' : 'padding-left'))
+        + parseInt(cStyle.getPropertyValue(height ? 'padding-bottom' : 'padding-right'))
+        + parseInt(cStyle.getPropertyValue(height ? 'border-top-width' : 'border-left-width'))
+        + parseInt(cStyle.getPropertyValue(height ? 'border-bottom-width' : 'border-right-width'));
+    } else {
+      ret = height ? elm.offsetHeight : elm.offsetWidth;
+    }
+    return ret;
+  };
+
+  function getOffsetWidth(elm) {
+    return _getOffset(elm);
+  };
+
+  function getOffsetHeight(elm) {
+    return _getOffset(elm, true);
+  };
+
   //safari 7 (and perhaps others) reports table width to be parent container's width if max-width is set on table. see: https://github.com/mkoryak/floatThead/issues/108
   var isTableWidthBug = function(){
     if(isWebkit) {
@@ -137,7 +163,7 @@
         w += parseInt($table.css("borderRight"), 10);
       }
       for(var i=0; i < $fthCells.length; i++){
-        w += $fthCells.get(i).offsetWidth;
+        w += getOffsetWidth($fthCells.get(i));
       }
       return w;
     } else {
@@ -484,7 +510,7 @@
             unfloat();
             var widths = [];
             for(i=0; i < numCols; i++){
-              widths[i] = $rowCells.get(i).offsetWidth;
+              widths[i] = getOffsetWidth($rowCells.get(i));
             }
             for(i=0; i < numCols; i++){
               $headerCells.eq(i).width(widths[i]);


### PR DESCRIPTION
in IE, offsetWidth returns an integer, but table cell width returns a
float, this causes cell text to be split over two lines

see https://github.com/mkoryak/floatThead/issues/167
