### PR TITLE
fix typo in internal debug() function

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -91,7 +91,7 @@
 
 
   function debug(str){
-    window.console && window.console && window.console.log && window.console.log("jQuery.floatThead: " + str);
+    window && window.console && window.console.log && window.console.log("jQuery.floatThead: " + str);
   }
 
   /**


### PR DESCRIPTION
Previously duplicated the `window.console` existence check. Could be that the
original author wanted to check for the `window` object existence instead or it
could be that one of the checks simply needs to be removed. I opted for the
former as a more conservative fix.