### PR TITLE
Fix table's within tables bug

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -420,8 +420,8 @@
           }
           $table.css(layoutFixed);
           $floatTable.css(layoutFixed);
-          $header.after($newHeader);
           $floatTable.append($header); //append because colgroup must go first in chrome
+          $tbody.before($newHeader);
           setHeaderHeight();
         }
       }

--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -201,8 +201,8 @@
         throw new Error('jQuery.floatThead must be run on a table element. ex: $("table").floatThead();');
       }
       canObserveMutations = opts.autoReflow && canObserveMutations; //option defaults to false!
-      var $header = $table.find('thead:first');
-      var $tbody = $table.find('tbody:first');
+      var $header = $table.children('thead:first');
+      var $tbody = $table.children('tbody:first');
       if($header.length == 0){
         throw new Error('jQuery.floatThead must be run on a table that contains a <thead> element');
       }
@@ -234,7 +234,7 @@
       var absoluteToFixedOnScroll = ieVersion <= 9 && !locked && useAbsolutePositioning; //on IE using absolute positioning doesn't look good with window scrolling, so we change position to fixed on scroll, and then change it back to absolute when done.
       var $floatTable = $("<table/>");
       var $floatColGroup = $("<colgroup/>");
-      var $tableColGroup = $table.find('colgroup:first');
+      var $tableColGroup = $table.children('colgroup:first');
       var existingColGroup = true;
       if($tableColGroup.length == 0){
         $tableColGroup = $("<colgroup/>");
@@ -323,7 +323,7 @@
 
       function setHeaderHeight(){
         var headerHeight = 0;
-        $header.find("tr:visible").each(function(){
+        $header.children("tr:visible").each(function(){
           headerHeight += $(this).outerHeight(true);
         });
         $sizerRow.outerHeight(headerHeight);
@@ -420,8 +420,8 @@
           }
           $table.css(layoutFixed);
           $floatTable.css(layoutFixed);
+          $header.after($newHeader);
           $floatTable.append($header); //append because colgroup must go first in chrome
-          $tbody.before($newHeader);
           setHeaderHeight();
         }
       }
@@ -808,9 +808,9 @@
         },
         getRowGroups: function(){
           if(headerFloated){
-            return $floatContainer.find("thead").add($table.find("tbody,tfoot"));
+            return $floatContainer.children("thead").add($table.children("tbody,tfoot"));
           } else {
-            return $table.find("thead,tbody,tfoot");
+            return $table.children("thead,tbody,tfoot");
           }
         }
       });


### PR DESCRIPTION
Nested tables inside the floated table header were having odd issues. These changes force floatThead to use only the thead/tbody belonging directly to the selected table(s). 

Bug: http://jsfiddle.net/z9t1wmg8/4/

In this example, the size-row gets inserted in the wrong table.

