### PR TITLE
package.json: change "filename" into "main"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "floatthead",
   "version": "1.2.10",
   "description": "fixed table header plugin that works",
-  "main": "jquery.floatThead.js",
+  "main": "dist/jquery.floatThead.js",
   "dependencies": {},
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "floatthead",
   "version": "1.2.10",
   "description": "fixed table header plugin that works",
-  "filename": "jquery.floatThead.js",
+  "main": "jquery.floatThead.js",
   "dependencies": {},
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
"main" is the official key to refer to the package entrypoint, see https://docs.npmjs.com/files/package.json

In particular, without this modification the package does not load in node (latest verisons) nor browserify.

```
> (adv-ui)[vperron@M]<~/dev/adv-ui> iopm install floatthead --save
> (adv-ui)[vperron@M]<~/dev/adv-ui> node
> require('floatthead')
Error: Cannot find module 'floatthead'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at repl:1:1
    at REPLServer.defaultEval (repl.js:132:27)
```

It works very well after this change.