### PR TITLE
fix wrong npm package name in "Install Using NPM"

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,7 +436,7 @@ bower install floatThead
         <br/>
         <h1>Install Using NPM</h1>
 {% highlight bash %}
-npm install floatThead
+npm install floatthead
 {% endhighlight %}
         <br/>
     </div>


### PR DESCRIPTION
Hi, I've noticed that the installing instruction in the [Download section](http://mkoryak.github.io/floatThead/#download) has some typo, the NPM package name should be `floatthead` instead of `floatThead`.

I tried searching npmjs.org to figure out that. :)