### PR TITLE
Set width to auto to float table header

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -368,7 +368,8 @@
       $floatTable.css({
         'borderCollapse': $table.css('borderCollapse'),
         'border': $table.css('border'),
-        'display': tableDisplayCss
+        'display': tableDisplayCss,
+        'width': 'auto'
       });
       if(tableDisplayCss == 'none'){
         floatTableHidden = true;


### PR DESCRIPTION
With css rule "table { width: 100%; }" and long paragraph in th cell, first few rows would be covered by floating header.

Fiddle: http://jsfiddle.net/nrjqf44e/3/  (first row is invisible.)