### PR TITLE
Possible fix for Issue#300 : Reflow When Table is Horizontally Scrolled.

### DIFF
--- a/dist/jquery.floatThead.js
+++ b/dist/jquery.floatThead.js
@@ -572,6 +572,8 @@
         var numCols = columnNum(); //if the tables columns changed dynamically since last time (datatables), rebuild the sizer rows and get a new count
 
         return function(){
+          //Cache the current scrollLeft value so that it can be reset post reflow
+          var scrollLeft = $floatContainer.scrollLeft();
           $tableCells = $tableColGroup.find('col');
           var $rowCells = getSizingRow($table, $tableCells, $fthCells, ieVersion);
 
@@ -597,7 +599,9 @@
             $floatTable.css(layoutAuto);
             setHeaderHeight();
           }
-          $table.triggerHandler("reflowed", [$floatContainer]);
+          //Set back the current scrollLeft value on floatContainer
+          $floatContainer.scrollLeft(scrollLeft);
+          $table.triggerHandler("reflowed", [$floatContainer]);          
         };
       }
 
@@ -1013,67 +1017,3 @@
     return this;
   };
 })(jQuery);
-/* jQuery.floatThead.utils - http://mkoryak.github.io/floatThead/ - Copyright (c) 2012 - 2016 Misha Koryak
- * License: MIT
- *
- * This file is required if you do not use underscore in your project and you want to use floatThead.
- * It contains functions from underscore that the plugin uses.
- *
- * YOU DON'T NEED TO INCLUDE THIS IF YOU ALREADY INCLUDE UNDERSCORE!
- *
- */
-
-(function($){
-
-  $.floatThead = $.floatThead || {};
-
-  $.floatThead._  = window._ || (function(){
-    var that = {};
-    var hasOwnProperty = Object.prototype.hasOwnProperty, isThings = ['Arguments', 'Function', 'String', 'Number', 'Date', 'RegExp'];
-    that.has = function(obj, key) {
-      return hasOwnProperty.call(obj, key);
-    };
-    that.keys = function(obj) {
-      if (obj !== Object(obj)) throw new TypeError('Invalid object');
-      var keys = [];
-      for (var key in obj) if (that.has(obj, key)) keys.push(key);
-      return keys;
-    };
-    var idCounter = 0;
-    that.uniqueId = function(prefix) {
-      var id = ++idCounter + '';
-      return prefix ? prefix + id : id;
-    };
-    $.each(isThings, function(){
-      var name = this;
-      that['is' + name] = function(obj) {
-        return Object.prototype.toString.call(obj) == '[object ' + name + ']';
-      };
-    });
-    that.debounce = function(func, wait, immediate) {
-      var timeout, args, context, timestamp, result;
-      return function() {
-        context = this;
-        args = arguments;
-        timestamp = new Date();
-        var later = function() {
-          var last = (new Date()) - timestamp;
-          if (last < wait) {
-            timeout = setTimeout(later, wait - last);
-          } else {
-            timeout = null;
-            if (!immediate) result = func.apply(context, args);
-          }
-        };
-        var callNow = immediate && !timeout;
-        if (!timeout) {
-          timeout = setTimeout(later, wait);
-        }
-        if (callNow) result = func.apply(context, args);
-        return result;
-      };
-    };
-    return that;
-  })();
-})(jQuery);
-

--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -572,6 +572,8 @@
         var numCols = columnNum(); //if the tables columns changed dynamically since last time (datatables), rebuild the sizer rows and get a new count
 
         return function(){
+          //Cache the current scrollLeft value so that it can be reset post reflow
+          var scrollLeft = $floatContainer.scrollLeft();
           $tableCells = $tableColGroup.find('col');
           var $rowCells = getSizingRow($table, $tableCells, $fthCells, ieVersion);
 
@@ -597,7 +599,9 @@
             $floatTable.css(layoutAuto);
             setHeaderHeight();
           }
-          $table.triggerHandler("reflowed", [$floatContainer]);
+          //Set back the current scrollLeft value on floatContainer
+          $floatContainer.scrollLeft(scrollLeft);
+          $table.triggerHandler("reflowed", [$floatContainer]);          
         };
       }
 

--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -601,7 +601,7 @@
           }
           //Set back the current scrollLeft value on floatContainer
           $floatContainer.scrollLeft(scrollLeft);
-          $table.triggerHandler("reflowed", [$floatContainer]);          
+          $table.triggerHandler("reflowed", [$floatContainer]);
         };
       }
 


### PR DESCRIPTION
Cache the scrollLeft value on floatContainer before reflow() and set it back on the floatContianer at end of reflow().