### PR TITLE
clear $fthRow before appending pseudo elements

### DIFF
--- a/jquery.floatThead.js
+++ b/jquery.floatThead.js
@@ -523,6 +523,7 @@
           cells = cells.join('');
 
           if(createElements){
+            $fthRow.empty();
             $fthRow.append(psuedo);
             $fthCells = $fthRow.find('fthtd');
           }


### PR DESCRIPTION
otherwise it will leave old and add new when number of columns changes.

Here is example after fix:
https://jsfiddle.net/adam187/3mx4LdLh
Here is example before fix: 
https://jsfiddle.net/adam187/3mx4LdLh/1/

When you resize window new `fthtd` will append each time when number of columns changes dynamically via css. 
![screen shot 2016-09-15 at 09 01 28](https://cloud.githubusercontent.com/assets/156628/18541144/93a1e19e-7b23-11e6-89e8-576c7f6707b6.png)



