### PR TITLE
Log error when a thead or tbody tag is missing

### DIFF
--- a/src/jquery.floatThead.js
+++ b/src/jquery.floatThead.js
@@ -304,6 +304,14 @@
       var $header = $table.children('thead:first');
       var $tbody = $table.children('tbody:first');
       if($header.length == 0 || $tbody.length == 0){
+        if(opts.debug) {
+          if($header.length == 0){
+            debug('Invalid thead. The thead element is either missing or empty.');
+          }
+          else{
+            debug('Invalid tbody. The tbody element is either missing or empty.');
+          }
+        }
         $table.data('floatThead-lazy', opts);
         $table.unbind("reflow").one('reflow', function(){
           $table.floatThead(opts);

--- a/src/jquery.floatThead.js
+++ b/src/jquery.floatThead.js
@@ -306,10 +306,10 @@
       if($header.length == 0 || $tbody.length == 0){
         if(opts.debug) {
           if($header.length == 0){
-            debug('The thead element is either missing or empty.');
+            debug('The thead element is missing.');
           }
           else{
-            debug('The tbody element is either missing or empty.');
+            debug('The tbody element is missing.');
           }
         }
         $table.data('floatThead-lazy', opts);

--- a/src/jquery.floatThead.js
+++ b/src/jquery.floatThead.js
@@ -306,10 +306,10 @@
       if($header.length == 0 || $tbody.length == 0){
         if(opts.debug) {
           if($header.length == 0){
-            debug('Invalid thead. The thead element is either missing or empty.');
+            debug('The thead element is either missing or empty.');
           }
           else{
-            debug('Invalid tbody. The tbody element is either missing or empty.');
+            debug('The tbody element is either missing or empty.');
           }
         }
         $table.data('floatThead-lazy', opts);


### PR DESCRIPTION
When the debug option is enabled, this will report when floatThead can't find the thead or tbody. Currently it just doesn't work without any notification. 

The help page should probably also mention that a tbody is needed. Browsers and other similar plugins can handle tables without it no problem, so it can be quite a challenging problem to find.