### PR TITLE
[Issue352] - move header back

### DIFF
--- a/src/jquery.floatThead.js
+++ b/src/jquery.floatThead.js
@@ -853,7 +853,7 @@
                 '-o-transform'      : transform,
                 'transform'         : transform,
                 'top': 0,
-                'left': 0
+                'left'				: -pos.left + 'px'
               });
             }
             oldTop = pos.top;


### PR DESCRIPTION
I tried to fix the issue
https://github.com/mkoryak/floatThead/issues/352
This bug fix works for me in case of `$table.floatThead({ position: 'absolute' });`