### PR TITLE
fix ipad retina table width issue

### DIFF
--- a/src/jquery.floatThead.js
+++ b/src/jquery.floatThead.js
@@ -237,7 +237,7 @@
         w += parseInt($table.css("borderRight"), 10);
       }
       for(var i=0; i < $fthCells.length; i++){
-        w += $fthCells.get(i).offsetWidth;
+        w += getOffsetWidth($fthCells.get(i));
       }
       return w;
     } else {


### PR DESCRIPTION
I had issue on iPad retina where table header was not aligned (had same width) with table. 

![screen shot 2017-03-15 at 09 49 12](https://cloud.githubusercontent.com/assets/156628/23944718/1d4aa604-0974-11e7-8cef-d7b359c154b3.png)

Reason for that was difference between table sizing columns and table width itself (from calculation). 

![screen shot 2017-03-15 at 09 49 29](https://cloud.githubusercontent.com/assets/156628/23944826/86965c20-0974-11e7-9b53-fe27cb451469.png)

Table sizing cols had fractions, but for table width calculation `offsetWidth` was used and it  [always return integers](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth).

Switching from `.offsetWidth` to  `getOffsetWidth()` for table width calculation solved problem.

`getOffsetWidth()` is using [getBoundingClientRect()](https://developer.mozilla.org/en/docs/Web/API/Element/getBoundingClientRect) which return width with fractions.