### PR TITLE
Fix HTML encoding of aria-label

### DIFF
--- a/src/jquery.floatThead.js
+++ b/src/jquery.floatThead.js
@@ -536,7 +536,7 @@
           lastColumnCount = count;
           var cells = [], cols = [], psuedo = [], content;
           for(var x = 0; x < count; x++){
-            content = $headerColumns.eq(x).text();
+            content = $headerColumns.eq(x).html();
             cells.push('<th class="floatThead-col" aria-label="'+content+'"/>');
             cols.push('<col/>');
             psuedo.push(


### PR DESCRIPTION
The production of the aria-label takes its content from the plain text header content. This means that header content that had HTML entities encoded has those HTML entities inserted into the aria-label unencoded. This patch fixes that.

This did get me thinking though: I think there are better ways of adding an aria label. In my case, the header content has a bunch of content including some HTML, and the aria label should only be part of that. It would be good if I could somehow specify what the aria-label should be, or even better define values for aria-labelledby. I would be happy to sponsor this work if you were interested in undertaking it.

In any case, thanks for a great module, and I will provide a separate donation anyway.