### PR TITLE
Fix destroy function when using autoReflow with multiple tables

### DIFF
--- a/src/jquery.floatThead.js
+++ b/src/jquery.floatThead.js
@@ -104,7 +104,7 @@
     return that;
   })();
 
-  var canObserveMutations = typeof MutationObserver !== 'undefined';
+  var globalCanObserveMutations = typeof MutationObserver !== 'undefined';
 
 
   //browser stuff
@@ -260,8 +260,6 @@
       return this; //no more crappy browser support.
     }
 
-    var mObs = null; //mutation observer lives in here if we can use it / make it
-
     if(util.isFunction(isTableWidthBug)) {
       isTableWidthBug = isTableWidthBug();
     }
@@ -309,7 +307,8 @@
       if(!$table.is('table')){
         throw new Error('jQuery.floatThead must be run on a table element. ex: $("table").floatThead();');
       }
-      canObserveMutations = opts.autoReflow && canObserveMutations; //option defaults to false!
+      var canObserveMutations = opts.autoReflow && globalCanObserveMutations; //option defaults to false!
+      var mObs = null; //mutation observer lives in here if we can use it / make it
       var $header = $table.children('thead:first');
       var $tbody = $table.children('tbody:first');
       if($header.length === 0 || $tbody.length === 0){


### PR DESCRIPTION
If you initialize multiple tables like so:

`$('.class').floatThead({autoReflow: true});`

They will share the same MutationObserver, and so calling...

`$('.class').floatThead('destroy');`

...will cause an error on the destroy for the second table.

Example: [https://codepen.io/mbogochow/pen/rNVJdpb](https://codepen.io/mbogochow/pen/rNVJdpb)

Simple fix is to move the `mObs` variable so that it is local to each table.  Similarly, I also added a local `canObserveMutations` variable so that each table does not overwrite the global variable depending on its options.